### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,11 +138,11 @@ resource "azurerm_monitor_diagnostic_setting" "namespace" {
   # For each available log category, check if it should be enabled and set enabled = true if it should.
   # All other categories are created with enabled = false to prevent TF from showing changes happening with each plan/apply.
   # Ref: https://github.com/terraform-providers/terraform-provider-azurerm/issues/7235
-  dynamic "log" {
+  dynamic "enabled_log" {
     for_each = data.azurerm_monitor_diagnostic_categories.default.log_category_types
     content {
-      category = log.value
-      enabled  = contains(local.parsed_diag.log, "all") || contains(local.parsed_diag.log, log.value)
+      category = enabled_log.value
+      enabled  = contains(local.parsed_diag.log, "all") || contains(local.parsed_diag.log, enabled_log.value)
 
       retention_policy {
         enabled = false


### PR DESCRIPTION
Resolve deprecation warning for:

Warning: Argument is deprecated 
with azurerm_monitor_diagnostic_setting.namespace[0], on main.tf line 129, in resource "azurerm_monitor_diagnostic_setting" "namespace": 129: resource "azurerm_monitor_diagnostic_setting" "namespace" {  `log` has been superseded by `enabled_log` and will be removed in version 4.0 of the AzureRM Provider.